### PR TITLE
Streamline dots handling in prodist generic/methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
 Config/testthat/parallel: true
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: distributions3
 Title: Probability Distributions as S3 Objects
-Version: 0.3.0
+Version: 0.3.0.99
 Authors@R: c(
     person(given = "Alex", family = "Hayes", email = "alexpghayes@gmail.com", role = "aut", comment = c(ORCID = "0000-0002-4985-5160")),
     person(given = "Ralph", family = "Moller-Trane", role = "aut", comment = c(ORCID = "0000-0001-7824-1785")),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -606,20 +606,26 @@ export(variance)
 import(stats)
 importFrom(graphics,hist)
 importFrom(parallel,detectCores)
-importFrom(rlang,.data)
-importFrom(rlang,check_dots_used)
-importFrom(stats,dnbinom)
-importFrom(stats,dpois)
-importFrom(stats,pnbinom)
-importFrom(stats,pnorm)
-importFrom(stats,ppois)
-importFrom(stats,qnbinom)
-importFrom(stats,qpois)
-importFrom(stats,rnbinom)
-importFrom(stats,rpois)
-importFrom(stats,runif)
-importFrom(stats,simulate)
-importFrom(stats,uniroot)
-importFrom(utils,getS3method)
-importFrom(utils,head)
+importFrom(rlang,
+  .data,
+  check_dots_used
+)
+importFrom(stats,
+  dnbinom,
+  dpois,
+  pnbinom,
+  pnorm,
+  ppois,
+  qnbinom,
+  qpois,
+  rnbinom,
+  rpois,
+  runif,
+  simulate,
+  uniroot
+)
+importFrom(utils,
+  getS3method,
+  head
+)
 useDynLib(distributions3, .registration = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# distributions3 0.3.0.99
+
+- Streamline dots `...` handling in `prodist` generic/methods (#140 and #141
+  by Achim Zeileis).
+
+
 # distributions3 0.3.0
 
 - New `Empirical()` distribution based on a random `sample`. This is particularly

--- a/R/prodist.R
+++ b/R/prodist.R
@@ -143,10 +143,8 @@
 #' ## Compute median (= mean) forecast along with 80% and 95% interval
 #' quantile(p, c(0.5, 0.1, 0.9, 0.025, 0.975))
 #'
-#' @importFrom rlang check_dots_used
 #' @export
 prodist <- function(object, ...) {
-  check_dots_used()
   UseMethod("prodist")
 }
 

--- a/R/prodist.R
+++ b/R/prodist.R
@@ -296,7 +296,17 @@ prodist.zerotrunc <- function(object, ...) {
 
 #' @rdname prodist
 #' @export
-prodist.distribution <- function(object, ...) object
+prodist.distribution <- function(object, ...) {
+  dots <- list(...)
+  if (!is.null(dots$newdata)) {
+    if (is.character(dots$na.action)) dots$na.action <- get(dots$na.action)
+    if (is.function(dots$na.action)) dots$newdata <- dots$na.action(dots$newdata)
+    if (length(object) != NROW(dots$newdata)) warning(sprintf(
+      "number of elements in 'object' (%s) and 'newdata' (%s) differ",
+      length(object), NROW(dots$newdata)))
+  }
+  return(object)
+}
 
 ## Further examples requiring other packages ---------------
 ## 

--- a/tests/testthat/test-check_dots_used.R
+++ b/tests/testthat/test-check_dots_used.R
@@ -211,24 +211,6 @@ test_that("is_continuous (generic function and methods) correctly use check_dots
 })
 
 
-# Distribution function prodist()
-test_that("prodist (generic function and methods) correctly use check_dots_used()", {
-    ## Ensure this is a generic function exported/provided by distributions3
-    expect_true("prodist" %in% ns)
-    expect_true(is_generic(prodist))
-    expect_true(has_check_dots_used(prodist))
-
-    ## S3 methods to check
-    methods <- get_methods(prodist, ns)
-
-    ## Given this is our own generic it should not include check_dots_used()
-    for (m in methods) {
-        res <- has_check_dots_used(getS3method("prodist", sub("^prodist\\.", "", m)))
-        expect_false(res, info = paste("check_dots_used() failed for:", m))
-    }
-})
-
-
 # Distribution function stuff_stat()
 test_that("suff_stat (generic function and methods) correctly use check_dots_used()", {
     ## Ensure this is a generic function exported/provided by distributions3


### PR DESCRIPTION
Fixes #140

- omit `check_dots_used` from `prodist` generic as potentially many different arguments might need to be passed through this like `newdata`, `na.action`, `n.ahead`, `dispersion`, etc.
- check in `prodist.distribution` whether distribution `object` and `newdata` (if any) have the same length